### PR TITLE
Fix packet in packet out

### DIFF
--- a/agent-click-file-gen.py
+++ b/agent-click-file-gen.py
@@ -70,15 +70,10 @@ print '''
 //
 '''
 
-#print '''
-#// call OdinAgent::configure to create and configure an Odin agent:
-#odinagent::OdinAgent(HWADDR %s, RT rates, CHANNEL %s, DEFAULT_GW %s, DEBUGFS %s, SSIDAGENT %s)
-#''' % (AP_UNIQUE_BSSID, AP_CHANNEL, DEFAULT_GW, DEBUGFS_FILE, SSIDAGENT )
-
 print '''
 // call OdinAgent::configure to create and configure an Odin agent:
-odinagent::OdinAgent(HWADDR %s, RT rates, CHANNEL %s, DEFAULT_GW %s, DEBUGFS %s)
-''' % (AP_UNIQUE_BSSID, AP_CHANNEL, DEFAULT_GW, DEBUGFS_FILE )
+odinagent::OdinAgent(HWADDR %s, RT rates, CHANNEL %s, DEFAULT_GW %s, DEBUGFS %s, SSIDAGENT %s)
+''' % (AP_UNIQUE_BSSID, AP_CHANNEL, DEFAULT_GW, DEBUGFS_FILE, SSIDAGENT )
 
 print '''
 // send a ping to odinsocket every 2 seconds

--- a/scripts_start_ap_odin/script_start_click.sh
+++ b/scripts_start_ap_odin/script_start_click.sh
@@ -2,5 +2,7 @@
 sleep 3
 ifconfig ap up
 ovs-vsctl --db=tcp:192.168.1.5:6632 add-port br0 ap
+sleep 3
+ovs-ofctl add-flow br0 in_port=1,dl_type=0x0800,nw_src=192.168.1.129,nw_dst=192.168.1.5,nw_proto=6,tp_dst=6777,actions=output:LOCAL
 
 

--- a/src/odinagent.hh
+++ b/src/odinagent.hh
@@ -79,6 +79,7 @@ public:
         String statistic;
         relation_t rel;
         double val;
+		Timestamp last_publish_sent; // Stores the timestamp when the last publish has been sent for a single subscription
   };
 
   // Methods to handle and send
@@ -150,6 +151,7 @@ public:
   // a per client basis
   HashTable<EtherAddress, OdinStationState> _sta_mapping_table;
   HashTable<EtherAddress, Timestamp> _mean_table;
+  HashTable<EtherAddress, Timestamp> _station_subs_table; // Table storing the last time when a publish for an ETH address has been sent
 
   // For stat collection
   double _mean;
@@ -186,6 +188,7 @@ private:
   Timer _general_timer;
   IPAddress _default_gw_addr;
   String _debugfs_string;
+  String _ssid_agent_string;	// stores the SSID of the agent
 };
 
 


### PR DESCRIPTION
1. **Improved Publish messages from the agent to the controller**
   New code has been added in order to:
- Reduce the number of probe requests forwarded to the controller. Only
  those with the odin SSID or broadcast (no SSID).
- Reduce the number of Publish sent by the agent as a consequence of
  subscriptions. A threshold is established for each subscription, so the
  agent will only send a Publish every interval (e.g. every 5 sec).
1. In `.cli` script: **New call to OdinAgent function**, with a new parameter SSIDAGENT.
2. Add a **new openflow rule**, which establishes the path for the control traffic between the
   controller and the agent (port 6777).
