### PR TITLE
Added different debug levels in the Odin agent

### DIFF
--- a/src/odinagent.hh
+++ b/src/odinagent.hh
@@ -173,7 +173,8 @@ public:
   int _csa_count; // For _csa FALSE-->TRUE
   int _csa_count_default;
   Vector<Subscription> _subscription_list;
-  bool _debug;
+  //bool _debug;
+  int _debug_level;		//"0" no info displayed; "1" only basic info displayed; "2" all the info displayed; "1x" demo info displayed
   HashTable<EtherAddress, String> _packet_buffer;
   void match_against_subscriptions(StationStats stats, EtherAddress src);
 


### PR DESCRIPTION
We have added different levels of debug in the odin agent. You must specify them in the .cli file, specified in the agent-cli-file-gen.py script.

You can define two different parameters:

$ python agent-click-file-gen.py 9 50 E8:DE:27:F7:01:E8 192.168.1.129
2819 /sys/kernel/debug/ieee80211/phy0/ath9k/bssid_extra odin-unizar
192.168.1.6 1 1

The last two parameters correspond to:
DEBUG_CLICK: "0" no info displayed; "1" only basic info displayed; "2"
all the info displayed

DEBUG_ODIN: "0" no info displayed; "1" only basic info displayed; "2"
all the info displayed; "1x" demo info displayed
